### PR TITLE
Updated features in chat lobby and create chat screens

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -10,8 +10,8 @@ const userSchema = new Schema({
   email: String,
   password: String,
   displayName: String,
-  chats: Array,
-  friends: Array
+  friends: Array,
+  friendRequests: Array
 })
 
 //Export this schema model for use in the index.js file

--- a/public/client.js
+++ b/public/client.js
@@ -91,12 +91,12 @@ $(function () {
 
     //Buttons displayed based on user type
     if (userType == "User"){
-      $('#chatEnterButton').show();
-      $('#chatApprovalButtons').hide();
+      $('#approveChatButton').hide();
+      $('#rejectChatButton').hide();
     }
     else if(userType == "Moderator"){
-      $('#chatEnterButton').hide();
-      $('#chatApprovalButtons').show();
+      $('#approveChatButton').show();
+      $('#rejectChatButton').show();
       
     }
   })  

--- a/public/client.js
+++ b/public/client.js
@@ -243,12 +243,6 @@ $(function () {
     $('#chat').css('display', 'contents');
   })
 
-  $('#chatToLobby').click(function(){
-    $('#chat').css('display', 'none');
-    $('#lobby').show();
-    updateChats();
-  })
-
   $('#messageForm').submit(function(e){
     e.preventDefault(); // prevents page reloading
     socket.emit('chat message', $('#m').val());

--- a/public/client.js
+++ b/public/client.js
@@ -238,7 +238,7 @@ $(function () {
 
 
   // Chat Logic
-  $('#chatEnterButton').click(function(){
+  $('#enterChatButton').click(function(){
     $('#lobby').hide();
     $('#chat').css('display', 'contents');
   })

--- a/public/client.js
+++ b/public/client.js
@@ -113,15 +113,6 @@ $(function () {
     $('#authentication').show();
   })
 
-// Will be replaced by Connors code. Delete this after merge
-  // // a button in lobby page, will take user to chat screen 
-  // $('#enterChatButton').click(function(){
-  //   $('#lobby').hide();
-  //   $('#chat').show();
-  // })
-
-
-
   
   /**
    * @Section Chat Creation
@@ -164,12 +155,6 @@ $(function () {
   })
 
   $('#submitChat').click(function(){
-    //alert(msg); //when they have no ppl in the chat?
-    //console.log($('#usersDisplay').val());
-    //$('#usersDisplay').val();
-    //$('#modDisplay').val();
-    //$("chat name").val();
-
     //Check if user has selected themselves or not. We cannot allow a user to create a chat in which they are not participating
     if($('#modDisplay').val().includes(displayName) || $('#usersDisplay').val().includes(displayName)){
       socket.emit('create chat', {users: $('#usersDisplay').val(), mods: $('#modDisplay').val(), chatname: $('#chatname').val()});
@@ -184,9 +169,11 @@ $(function () {
     $('#lobby').show();
     $('#chatCreate').hide();
   })
+
   socket.on('chat create failure', function(userObj){
     alert(userObj);
   })
+
   //a button take user to char create page
   $('#createChatButton').click(function(){
     $('#lobby').hide();
@@ -231,10 +218,6 @@ $(function () {
       });
     })
   }
-
-  
-
-
 
 
   // Chat Logic

--- a/public/index.html
+++ b/public/index.html
@@ -98,7 +98,7 @@
       <div id="chatLayout">
         <!--Chat Header-->
         <div id="FunChatLabel" class="flexRow">
-          <button id="chatToLobby" class="chatButtons"><i class="fas fa-arrow-left"></i>Lobby</button>
+          <button id="goHome" class="chatButtons"><i class="fas fa-arrow-left"></i>Home</button>
           FunChat
           <div id="centering"></div>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -78,16 +78,9 @@
         <option value="option2">chat 2</option>
       </select><br>
 
-      <!---Display this button if the person is a user-->
-      <div id = "chatEnterButton">
-        <button id="enterChatButton1" type="button">enter chat</button>
-        <!---Why are there two enter chat buttons?-->
-        <!----<button id="enterChatButton2" type="button">enter chat</button>----->
-      </div>
- 
-      <!---Display these buttons if the person is a moderator-->
-      <div id ="chatApprovalButtons">
-        <button id="enterChatButton3" type="button">enter chat</button>
+      <!---Lobby buttons - display approve/reject buttons only if user is a Mod-->
+      <div id ="chatLobbyButtons">
+        <button id="enterChatButton" type="button">enter chat</button>
         <button id="approveChatButton" type="button">approve chat</button>
         <button id="rejectChatButton" type="button"> reject chat</button>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -80,12 +80,14 @@
 
       <!---Display this button if the person is a user-->
       <div id = "chatEnterButton">
-      <button id="enterChatButton" type="button">enter chat</button>  
-        <button id="enterChatButton" type="button">enter chat</button>
+        <button id="enterChatButton1" type="button">enter chat</button>
+        <!---Why are there two enter chat buttons?-->
+        <!----<button id="enterChatButton2" type="button">enter chat</button>----->
       </div>
  
       <!---Display these buttons if the person is a moderator-->
       <div id ="chatApprovalButtons">
+        <button id="enterChatButton3" type="button">enter chat</button>
         <button id="approveChatButton" type="button">approve chat</button>
         <button id="rejectChatButton" type="button"> reject chat</button>
       </div>
@@ -96,7 +98,7 @@
       <div id="chatLayout">
         <!--Chat Header-->
         <div id="FunChatLabel" class="flexRow">
-          <button id="goHome" class="chatButtons"><i class="fas fa-arrow-left"></i>Home</button>
+          <button id="chatToLobby" class="chatButtons"><i class="fas fa-arrow-left"></i>Lobby</button>
           FunChat
           <div id="centering"></div>
         </div>

--- a/server.js
+++ b/server.js
@@ -138,7 +138,7 @@ io.on('connection', function(socket){
               else 
               {
                 console.log("added");
-                socket.emit("chat create success", "Create of " + obj.chatname + " Chat Successful");
+                socket.emit("chat create success", "Creation of Chat: " + obj.chatname + " Successful");
               }
             })
           }
@@ -191,24 +191,28 @@ io.on('connection', function(socket){
   })
 
 
-  updatechat()
+  //updatechat()
   
+  socket.on("refreshChatList", function(userName){
+    updatechat(userName);
+  })
 
   //read the chat rooms from database, send them to client side
- async function updatechat(){
+ async function updatechat(userName){
   var chats = []
   //read all the chat rooms in chat and put them into a array called chats
   await chat.find({}, function(err, result) {
-   result.forEach(function(user) {
-    console.log(user.name);
-    chats.push(user.name);
+   result.forEach(function(userChat) {
+     if(userChat.participants.includes(userName) || userChat.mods.includes(userName)){
+      console.log(userChat.name);
+      chats.push(userChat.name);
+     }
+    
     }); 
   });
   console.log(chats)
   //send the chats to client side
-  socket.emit("updateChats",chats,function(){
-
-  });
+  socket.emit("updateChats",chats);
 
  }
 });


### PR DESCRIPTION
**The following updates have been made to the lobby and create chat screens:**

- When user is creating a new chat, the application will check whether the user has selected themselves as one of the participants/mods. If user did not select themselves, they will be given a message. This prevents people from creating chats that include other people but not themselves.

- When new chat was created, the chats list was not being updated to show the new chat. This has been fixed by adjusting Xudong's code and calling the updateChats() method in appropriate places to keep the list updated with all changes.

- **Chat list will now only display the chats in which the current user is listed as a participant or mod**

- Fixed sentence grammar for the successful chat creation message

- The "Home" button in the chat screen was not working. I changed it to say Lobby and added click functionality so that it will take user back to lobby. **This has been removed as Liam is implementing it**

- Added a message to the approve chat button to let the mod know they have successfully approved the chat

- Removed the chats field from the user schema. I believe we don't need this as the chat objects already contain information about who is participant/mod

- Mods did not have the ability to enter a chat so I added a button to let them enter chats.